### PR TITLE
Added version 15 to _sql_server_versions

### DIFF
--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -157,6 +157,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         12: 2014,
         13: 2016,
         14: 2017,
+        15: 2017,
     }
 
     # https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-csharp-retry-windows/


### PR DESCRIPTION
The code works with SQL Server 2019 v15 as is, however it throws an error because 15 is not in the list of supported version. Adding it resolves this error.